### PR TITLE
[9.x] Adds support for Parallel Testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,6 +131,7 @@
         "ext-posix": "Required to use all features of the queue worker.",
         "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
         "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.155).",
+        "brianium/paratest": "Required to run tests in parallel (^6.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6|^3.0).",
         "filp/whoops": "Required for friendly error pages in development (^2.8).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -95,6 +95,28 @@ class Builder
     }
 
     /**
+     * Create a database in the schema if the database not exists.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function createDatabaseIfNotExists($name)
+    {
+        throw new LogicException('This database driver does not support create databases.');
+    }
+
+    /**
+     * Drop a database from the schema if the database exists.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function dropDatabaseIfExists($name)
+    {
+        throw new LogicException('This database driver does not support drop databases.');
+    }
+
+    /**
      * Determine if the given table exists.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
+use LogicException;
 use RuntimeException;
 
 abstract class Grammar extends BaseGrammar
@@ -26,6 +27,29 @@ abstract class Grammar extends BaseGrammar
      * @var array
      */
     protected $fluentCommands = [];
+
+    /**
+     * Compile a create database if not exists command.
+     *
+     * @param  string $name
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return string
+     */
+    public function compileCreateDatabaseIfNotExists($name, $connection)
+    {
+        throw new LogicException('This database driver does not support create databases.');
+    }
+
+    /**
+     * Compile a drop database if exists command.
+     *
+     * @param  string $name
+     * @return string
+     */
+    public function compileDropDatabaseIfExists($name)
+    {
+        throw new LogicException('This database driver does not support drop databases.');
+    }
 
     /**
      * Compile a rename column command.

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -27,6 +27,37 @@ class MySqlGrammar extends Grammar
     protected $serials = ['bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger'];
 
     /**
+     * Compile a create database if not exists command.
+     *
+     * @param  string $name
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return string
+     */
+    public function compileCreateDatabaseIfNotExists($name, $connection)
+    {
+        return sprintf(
+            'CREATE DATABASE IF NOT EXISTS %s CHARACTER SET %s COLLATE %s;',
+            $this->wrapValue($name),
+            $this->wrapValue($connection->getConfig('charset')),
+            $this->wrapValue($connection->getConfig('collation')),
+        );
+    }
+
+    /**
+     * Compile a drop database if exists command.
+     *
+     * @param  string $name
+     * @return string
+     */
+    public function compileDropDatabaseIfExists($name)
+    {
+        return sprintf(
+            'DROP DATABASE IF EXISTS %s;',
+            $this->wrapValue($name)
+        );
+    }
+
+    /**
      * Compile the query to determine the list of tables.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -5,6 +5,32 @@ namespace Illuminate\Database\Schema;
 class MySqlBuilder extends Builder
 {
     /**
+     * Create a database in the schema if the database not exists.
+     *
+     * @param  string $name
+     * @return bool
+     */
+    public function createDatabaseIfNotExists($name)
+    {
+        return $this->connection->statement(
+            $this->grammar->compileCreateDatabaseIfNotExists($name, $this->connection)
+        );
+    }
+
+    /**
+     * Drop a database from the schema if the database exists.
+     *
+     * @param  string $name
+     * @return bool
+     */
+    public function dropDatabaseIfExists($name)
+    {
+        return $this->connection->statement(
+            $this->grammar->compileDropDatabaseIfExists($name)
+        );
+    }
+
+    /**
      * Determine if the given table exists.
      *
      * @param  string  $table

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Testing;
 
 trait RefreshDatabase
 {
@@ -13,9 +15,15 @@ trait RefreshDatabase
      */
     public function refreshDatabase()
     {
-        $this->usingInMemoryDatabase()
-                        ? $this->refreshInMemoryDatabase()
-                        : $this->refreshTestDatabase();
+        if ($this->usingInMemoryDatabase()) {
+            return $this->refreshInMemoryDatabase();
+        }
+
+        Testing::whenRunningInParallel(function () {
+            $this->switchToTemporaryDatabase();
+        });
+
+        $this->refreshTestDatabase();
     }
 
     /**
@@ -28,6 +36,67 @@ trait RefreshDatabase
         $default = config('database.default');
 
         return config("database.connections.$default.database") === ':memory:';
+    }
+
+    /**
+     * Switch to the temporary test database.
+     *
+     * @return void
+     */
+    protected function switchToTemporaryDatabase()
+    {
+        $default = config('database.default');
+
+        config()->set(
+            "database.connections.{$default}.database",
+            RefreshDatabaseState::$temporaryDatabase,
+        );
+    }
+
+    /**
+     * Creates a temporary database, if needed.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTemporaryDatabase()
+    {
+        tap(new static(), function ($testCase) {
+            $testCase->refreshApplication();
+
+            if ($testCase->usingInMemoryDatabase()) {
+                return;
+            }
+
+            Testing::whenRunningInParallel(function () use ($testCase) {
+                $name = $testCase->getConnection()->getConfig('database');
+
+                Schema::createDatabaseIfNotExists(
+                    RefreshDatabaseState::$temporaryDatabase = Testing::addTokenIfNeeded($name)
+                );
+            });
+        })->app->flush();
+    }
+
+    /**
+     * Drop the temporary database, if any.
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public static function tearDownTemporaryDatabase()
+    {
+        if (RefreshDatabaseState::$temporaryDatabase) {
+            tap(new static(), function ($testCase) {
+                $testCase->refreshApplication();
+
+                Schema::dropDatabaseIfExists(
+                    RefreshDatabaseState::$temporaryDatabase,
+                );
+            })->app->flush();
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/RefreshDatabaseState.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabaseState.php
@@ -10,4 +10,11 @@ class RefreshDatabaseState
      * @var bool
      */
     public static $migrated = false;
+
+    /**
+     * The temporary database name, if any.
+     *
+     * @var string|null
+     */
+    public static $temporaryDatabase;
 }

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -4,8 +4,10 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Database\Schema\Builder create(string $table, \Closure $callback)
+ * @method static \Illuminate\Database\Schema\Builder createDatabaseIfNotExists(string $name)
  * @method static \Illuminate\Database\Schema\Builder disableForeignKeyConstraints()
  * @method static \Illuminate\Database\Schema\Builder drop(string $table)
+ * @method static \Illuminate\Database\Schema\Builder dropDatabaseIfExists(string $name)
  * @method static \Illuminate\Database\Schema\Builder dropIfExists(string $table)
  * @method static \Illuminate\Database\Schema\Builder enableForeignKeyConstraints()
  * @method static \Illuminate\Database\Schema\Builder rename(string $from, string $to)

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -54,6 +54,8 @@ class Storage extends Facade
             $root = storage_path('framework/testing/disks/'.$disk)
         );
 
+        $root = Testing::addTokenIfNeeded($root);
+
         static::set($disk, $fake = static::createLocalDriver(array_merge($config, [
             'root' => $root,
         ])));

--- a/src/Illuminate/Support/Facades/Testing.php
+++ b/src/Illuminate/Support/Facades/Testing.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * @method static string addTokenIfNeeded(string $string)
+ * @method static void whenRunningInParallel(callable $callback)
+ *
+ * @see \Illuminate\Testing\Testing
+ */
+class Testing extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return \Illuminate\Testing\Testing::class;
+    }
+}

--- a/src/Illuminate/Testing/Testing.php
+++ b/src/Illuminate/Testing/Testing.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Testing;
+
+use Illuminate\Contracts\Foundation\Application;
+
+class Testing
+{
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * The token resolver callback.
+     *
+     * @var \Closure|null
+     */
+    protected static $tokenResolver;
+
+    /**
+     * Create a new Testing instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application $app
+     * @return void
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Adds an unique test token to the given string, if needed.
+     *
+     * @return string
+     */
+    public function addTokenIfNeeded($string)
+    {
+        if (! $this->inParallel()) {
+            return $string;
+        }
+
+        return "{$string}_test_{$this->token()}";
+    }
+
+    /**
+     * Apply the callback if tests are running in parallel.
+     *
+     * @param  callable $callback
+     * @return void
+     */
+    public function whenRunningInParallel($callback)
+    {
+        if ($this->inParallel()) {
+            $callback();
+        }
+    }
+
+    /**
+     * Indicates if the current tests are been run in Parallel.
+     *
+     * @return bool
+     */
+    protected function inParallel()
+    {
+        return $this->app->runningUnitTests() && getenv('LARAVEL_PARALLEL_TESTING') && $this->token();
+    }
+
+    /**
+     * Gets an unique test token.
+     *
+     * @return int|false
+     */
+    protected function token()
+    {
+        return static::$tokenResolver
+            ? call_user_func(static::$tokenResolver)
+            : getenv('TEST_TOKEN');
+    }
+
+    /**
+     * Set with token resolver callback.
+     *
+     * @param  \Closure|null  $resolver
+     * @return void
+     */
+    public static function tokenResolver($resolver)
+    {
+        static::$tokenResolver = $resolver;
+    }
+}

--- a/tests/Database/DatabaseAbstractSchemaGrammarTest.php
+++ b/tests/Database/DatabaseAbstractSchemaGrammarTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Grammars\Grammar;
+use LogicException;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseAbstractSchemaGrammarTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testCreateDatabaseIfNotExists()
+    {
+        $grammar = new class extends Grammar {};
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('This database driver does not support create databases.');
+
+        $grammar->compileCreateDatabaseIfNotExists('foo', m::mock(Connection::class));
+    }
+
+    public function testDropDatabaseIfExists()
+    {
+        $grammar = new class extends Grammar {};
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('This database driver does not support drop databases.');
+
+        $grammar->compileDropDatabaseIfExists('foo');
+    }
+}

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1149,6 +1149,48 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
     }
 
+    public function testCreateDatabaseIfNotExists()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getConfig')->once()->once()->with('charset')->andReturn('utf8mb4_foo');
+        $connection->shouldReceive('getConfig')->once()->once()->with('collation')->andReturn('utf8mb4_unicode_ci_foo');
+
+        $statement = $this->getGrammar()->compileCreateDatabaseIfNotExists('my_database_a', $connection);
+
+        $this->assertSame(
+            'CREATE DATABASE IF NOT EXISTS `my_database_a` CHARACTER SET `utf8mb4_foo` COLLATE `utf8mb4_unicode_ci_foo`;',
+            $statement
+        );
+
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getConfig')->once()->once()->with('charset')->andReturn('utf8mb4_bar');
+        $connection->shouldReceive('getConfig')->once()->once()->with('collation')->andReturn('utf8mb4_unicode_ci_bar');
+
+        $statement = $this->getGrammar()->compileCreateDatabaseIfNotExists('my_database_b', $connection);
+
+        $this->assertSame(
+            'CREATE DATABASE IF NOT EXISTS `my_database_b` CHARACTER SET `utf8mb4_bar` COLLATE `utf8mb4_unicode_ci_bar`;',
+            $statement
+        );
+    }
+
+    public function testDropDatabaseIfExists()
+    {
+        $statement = $this->getGrammar()->compileDropDatabaseIfExists('my_database_a');
+
+        $this->assertSame(
+            'DROP DATABASE IF EXISTS `my_database_a`;',
+            $statement
+        );
+
+        $statement = $this->getGrammar()->compileDropDatabaseIfExists('my_database_b');
+
+        $this->assertSame(
+            'DROP DATABASE IF EXISTS `my_database_b`;',
+            $statement
+        );
+    }
+
     public function testDropAllTables()
     {
         $statement = $this->getGrammar()->compileDropAllTables(['alpha', 'beta', 'gamma']);

--- a/tests/Database/DatabaseMysqlBuilderTest.php
+++ b/tests/Database/DatabaseMysqlBuilderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Grammars\MysqlGrammar;
+use Illuminate\Database\Schema\MysqlBuilder;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseMysqlBuilderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testCreateDatabaseIfNotExists()
+    {
+        $grammar = new MysqlGrammar();
+
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getConfig')->once()->once()->with('charset')->andReturn('utf8mb4');
+        $connection->shouldReceive('getConfig')->once()->once()->with('collation')->andReturn('utf8mb4_unicode_ci');
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $connection->shouldReceive('statement')->once()->with(
+            'CREATE DATABASE IF NOT EXISTS `my_temporary_database` CHARACTER SET `utf8mb4` COLLATE `utf8mb4_unicode_ci`;'
+        )->andReturn(true);
+
+        $builder = new MysqlBuilder($connection);
+        $builder->createDatabaseIfNotExists('my_temporary_database');
+    }
+
+    public function testDropDatabaseIfExists()
+    {
+        $grammar = new MysqlGrammar();
+
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $connection->shouldReceive('statement')->once()->with(
+            'DROP DATABASE IF EXISTS `my_database_a`;'
+        )->andReturn(true);
+
+        $builder = new MysqlBuilder($connection);
+
+        $builder->dropDatabaseIfExists('my_database_a');
+    }
+}

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Builder;
+use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -13,6 +14,32 @@ class DatabaseSchemaBuilderTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+    }
+
+    public function testCreateDatabaseIfNotExists()
+    {
+        $connection = m::mock(Connection::class);
+        $grammar = m::mock(stdClass::class);
+        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
+        $builder = new Builder($connection);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('This database driver does not support create databases.');
+
+        $builder->createDatabaseIfNotExists('foo');
+    }
+
+    public function testDropDatabaseIfExists()
+    {
+        $connection = m::mock(Connection::class);
+        $grammar = m::mock(stdClass::class);
+        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
+        $builder = new Builder($connection);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('This database driver does not support drop databases.');
+
+        $builder->dropDatabaseIfExists('foo');
     }
 
     public function testHasTableCorrectlyCallsGrammar()

--- a/tests/Testing/TestingTest.php
+++ b/tests/Testing/TestingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Testing\Testing;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class TestingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        putenv('LARAVEL_PARALLEL_TESTING=1');
+    }
+
+    public function testWhenRunningInParallel()
+    {
+        $app = m::mock(Application::class);
+
+        $app->shouldReceive('runningUnitTests')
+            ->once()
+            ->andReturn(false);
+
+        $testing = new Testing($app);
+        $run = false;
+
+        $testing->whenRunningInParallel(function () use (&$run) {
+            $run = true;
+        });
+        $this->assertFalse($run);
+
+        $app->shouldReceive('runningUnitTests')
+            ->once()
+            ->andReturn(true);
+
+        Testing::tokenResolver(function () {
+            return 1;
+        });
+
+        $testing->whenRunningInParallel(function () use (&$run) {
+            $run = true;
+        });
+        $this->assertTrue($run);
+    }
+
+    public function testAddTokenIfNeeded()
+    {
+        $app = m::mock(Application::class);
+
+        $app->shouldReceive('runningUnitTests')
+            ->once()
+            ->andReturn(false);
+
+        $this->assertSame(
+            'my_local_storage',
+            (new Testing($app))->addTokenIfNeeded('my_local_storage')
+        );
+
+        $app->shouldReceive('runningUnitTests')
+            ->once()
+            ->andReturn(true);
+
+        Testing::tokenResolver(function () {
+            return 1;
+        });
+
+        $this->assertSame(
+            'my_local_storage_test_1',
+            (new Testing($app))->addTokenIfNeeded('my_local_storage')
+        );
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+        Testing::tokenResolver(null);
+        putenv('LARAVEL_PARALLEL_TESTING=0');
+    }
+}


### PR DESCRIPTION
This pull request adds support for **Parallel Testing** in Laravel 9.

## Overview

As you may know, Laravel 5.7 introduced the `php artisan test` command that you may use to test your applications. In this pull request, we introduce the `--parallel` option that you may use to run your **tests in parallel**:

<img width="100%" alt="Screenshot 2021-01-04 at 15 36 25" src="https://user-images.githubusercontent.com/5457236/103546000-a5e74e00-4ea2-11eb-9997-a4efdfda312c.png">

Of course, by default, your application may not have all the dependencies needed by this feature - such us `brianium/paratest` - so we will confirm with the users if we can install the dependencies for them:

<img width="1137" alt="Screenshot 2021-01-04 at 15 39 30" src="https://user-images.githubusercontent.com/5457236/103546300-0c6c6c00-4ea3-11eb-88a0-82c5f63b1c88.png">

Finally, the results are pretty impressive. As an example, running the [Laravel.io](https://github.com/laravelio/laravel.io) test suite, we went from 90 seconds down to **19 seconds**. **Almost 5x faster** in my 6-Core Intel Core i7. 🚀🚀🚀

## Implemention

The implementation of this pull request consists of modifying the framework's code so tests can be run in Parallel. Behind the scenes, the `php artisan test --parallel` command, will run `LARAVEL_PARALLEL_TESTING=1 ./vendor/bin/paratest` and `LARAVEL_PARALLEL_TESTING=1` will instruct the framework that tests are being run in parallel.

Pull request that introduces the `--parallel` in the `php artisan test` command: [nunomaduro/collision/pull/168](https://github.com/nunomaduro/collision/pull/168).

Of course, by default, the env `LARAVEL_PARALLEL_TESTING` does not exist, so the code introduced in this pull request won't change a thing for people who don't want to use parallel testing.

Now, because PHP lacks native threads, the typical way of achieving some level of concurrency is using processes - like Laravel Queues. Therefore, we are using Parallel Testing with processes. By default, we will use the number of CPU cores as the number of processes. Of course, people can tinker with this value like so:

```bash
php artisan test --parallel --processes=8
```

Keep in mind, when we talk about parallel testing with processes, is just about running `./vendor/bin/phpunit` on each test case, at the same time, and aggregate the results at the end. And this is what the `brianium/paratest` dependency does for us.

Now, if multiple tests are using the `RefreshDatabase::class` trait, Laravel applications will probably have some failing tests - that happens because one test may be refreshing the database, while the database is being used by another test in a different process.

To mitigate the database issue, this pull request automatically handles creating a database and loading the schema into the database for each test case. The databases will be suffixed with the number corresponding to the process. For example, if you have 2 processes, each test case will create `your_database_test_1` and `your_database_test_2` respectively. Keep in mind, you still need an active database connection to the `your_database`.

More precisely, we are just using the `@beforeClass` and `@afterClass` features in PHPUnit to create a temporary database per test class. No worries, once the test case is over, and cleanup is performed.

Of course, the same goes for the Storage::fake, while using `Storage::fake('local')`, we create multiple local storages like so: `local_test_1` and `local_test_2`.

--- 

This pull request is at draft state, as there are still some remaining tasks. Yet, feel free to give some feedback. Remaining tasks:

- [ ] Add support for PostgreSQL.
- [ ] Add support for SQL Server.
- [ ] Merge and tag the collision pull request: 
- [ ] Update required version of Collision on the skeleton for Laravel 9.
- [ ] Add documentation